### PR TITLE
Fixed a compilation error for gcc-11.2.0

### DIFF
--- a/src/MatchManager.cpp
+++ b/src/MatchManager.cpp
@@ -16,6 +16,7 @@
 
 #include "MatchManager.h"
 #include <algorithm>
+#include <limits>
 
 MatchManager::MatchManager() {
 


### PR DESCRIPTION
GCC-11.2.0 does not compile App-SpaM because of a missing header for std::numeric_limits:

```
/shared/projects/rappas2/appspam/src/MatchManager.cpp: In member function 'std::vector<Match> MatchManager::get_highest_scoring_matches()':
/shared/projects/rappas2/appspam/src/MatchManager.cpp:60:46: error: 'numeric_limits' is not a member of 'std'
   60 |                         int max_score = std::numeric_limits<double>::min();
      |                                              ^~~~~~~~~~~~~~
/shared/projects/rappas2/appspam/src/MatchManager.cpp:60:61: error: expected primary-expression before 'double'
   60 |                         int max_score = std::numeric_limits<double>::min();
      |                                                             ^~~~~~
```

I fixed it.